### PR TITLE
This commit migrates two additional cards to the new tiered data stru…

### DIFF
--- a/src/content/cards/crypto-com-card.md
+++ b/src/content/cards/crypto-com-card.md
@@ -3,15 +3,13 @@ title: "Crypto.com Visa卡 - 高返现金属U卡"
 name: "Crypto.com Card"
 description: "Crypto.com提供一系列等级分明的金属Visa卡，质押CRO代币可享受高额返现和多种福利。"
 cardType: "visa"
-isVirtual: true
-isPhysical: true
 issuer: "Crypto.com"
 supportedRegions:
   - "美国"
   - "加拿大"
   - "欧洲"
   - "亚太地区"
-applicationDocuments: []
+applicationDocuments: ["身份验证 (KYC)"]
 supportedCurrencies:
   - "BTC"
   - "ETH"
@@ -22,19 +20,11 @@ supportedCurrencies:
 supportedPaymentMethods:
   - "Apple Pay"
   - "Google Pay"
-virtualCardPrice: 0
-physicalCardPrice: 0
-depositFee: "免费"
-transactionFee: "免费"
-withdrawalFee: "根据等级有免费额度"
-atmFee: "根据等级有免费额度"
-annualFee: false
-limits:
-  dailySpending: "$25,000"
-  monthlySpending: "$25,000"
-  monthlyAtmWithdrawal: "$1,000"
-rewards:
-  cashback: "最高5%的CRO返现"
+rating: 4.8
+affiliateLink: "https://crypto.com/app/"
+publishDate: "2024-01-05"
+updateDate: "2025-08-11"
+kycRequired: true
 pros:
   - "高额消费返现"
   - "金属卡片，质感好"
@@ -49,19 +39,62 @@ features:
   - "机场贵宾厅"
   - "订阅服务报销"
   - "金属卡"
-relatedArticles:
-  - "crypto-com-staking-guide"
-affiliateLink: "https://crypto.com/app/"
 tags:
   - "Crypto.com"
   - "CRO"
   - "返现"
   - "金属卡"
   - "U卡"
-publishDate: "2024-01-05"
-updateDate: "2024-03-01"
-rating: 4.8
-kycRequired: true
+
+tiers:
+  - name: "Midnight Blue"
+    theme: "blue"
+    isPhysical: true
+    cardMaterial: "塑料卡"
+    price: "免费"
+    priceUnit: "无需质押"
+    fees:
+      "CRO 质押": "无"
+      "月费": "免费"
+    rewards:
+      title: "基础功能"
+      features:
+        - "0% CRO 返现"
+    limits:
+      "ATM免费提现额度": "$200/月"
+  - name: "Ruby Steel"
+    theme: "dark"
+    isPhysical: true
+    cardMaterial: "金属卡"
+    price: "$400"
+    priceUnit: "CRO质押"
+    fees:
+      "CRO 质押": "$400"
+      "月费": "免费"
+    rewards:
+      title: "奖励与福利"
+      features:
+        - "1% CRO 返现"
+        - "Spotify 全额报销 (首6个月)"
+    limits:
+      "ATM免费提现额度": "$400/月"
+  - name: "Jade Green / Royal Indigo"
+    theme: "green"
+    isPhysical: true
+    cardMaterial: "金属卡"
+    price: "$4,000"
+    priceUnit: "CRO质押"
+    fees:
+      "CRO 质押": "$4,000"
+      "月费": "免费"
+    rewards:
+      title: "奖励与福利"
+      features:
+        - "2% CRO 返现"
+        - "Spotify & Netflix 全额报销 (首6个月)"
+        - "机场贵宾厅 (LoungeKey™)"
+    limits:
+      "ATM免费提现额度": "$800/月"
 ---
 
 ## Crypto.com Visa 卡评测

--- a/src/content/cards/onekey-card.md
+++ b/src/content/cards/onekey-card.md
@@ -3,8 +3,6 @@ title: "OneKey Card - 安全便捷的硬件钱包U卡"
 name: "OneKey Card"
 description: "OneKey硬件钱包推出的Visa虚拟卡，主打安全性和隐私保护，支持多种加密货币。"
 cardType: "visa"
-isVirtual: true
-isPhysical: false
 issuer: "OneKey"
 supportedRegions:
   - "全球大部分地区"
@@ -19,20 +17,11 @@ supportedPaymentMethods:
   - "Google Pay"
   - "Alipay"
   - "WeChat Pay"
-virtualCardPrice: 10
-physicalCardPrice: null
-depositFee: "1%"
-transactionFee: "1.5%"
-withdrawalFee: "不适用"
-atmFee: null
-annualFee: false
-limits:
-  dailySpending: "$5,000"
-  monthlySpending: "$50,000"
-  dailyAtmWithdrawal: "$500"
-  monthlyAtmWithdrawal: "$5,000"
-rewards:
-  cashback: "消费返还KEY代币"
+rating: 4.7
+affiliateLink: "https://onekey.so/card"
+publishDate: "2024-03-10"
+updateDate: "2025-08-11"
+kycRequired: true
 pros:
   - "与OneKey硬件钱包无缝集成，安全性高"
   - "支持多种主流稳定币和加密货币"
@@ -46,19 +35,34 @@ features:
   - "硬件钱包集成"
   - "多重安全验证"
   - "隐私保护"
-relatedArticles:
-  - "onekey-wallet-guide"
-affiliateLink: "https://onekey.so/card"
 tags:
   - "OneKey"
   - "硬件钱包"
   - "U卡"
   - "安全"
   - "隐私"
-publishDate: "2024-03-10"
-updateDate: "2025-08-08"
-rating: 4.7
-kycRequired: true
+
+tiers:
+  - name: "Standard"
+    theme: "gray"
+    isVirtual: true
+    isPhysical: false
+    cardMaterial: "虚拟卡"
+    price: "$10"
+    priceUnit: "开卡费"
+    fees:
+      "充值费": "1%"
+      "交易费": "1.5%"
+      "年费": "免费"
+    rewards:
+      title: "返现奖励"
+      features:
+        - "消费返还KEY代币"
+    limits:
+      "每日消费": "$5,000"
+      "每月消费": "$50,000"
+      "每日ATM提现": "$500"
+      "每月ATM提现": "$5,000"
 ---
 
 ## OneKey Card 评测

--- a/src/pages/cards/[slug].astro
+++ b/src/pages/cards/[slug].astro
@@ -125,7 +125,7 @@ const relatedArticles = allArticles
 // 渲染Markdown内容
 const { Content } = await card.render();
 
-import { getEnhancedCurrencyInfo, getPaymentMethodInfo } from '../../config/site-data';
+import { getCurrencyInfo, getPaymentMethodInfo } from '../../config/site-data';
 
 // 生成结构化数据
 const structuredData = {
@@ -344,7 +344,22 @@ const structuredData = {
           ) : (
             <div class="space-y-8">
               {/* Legacy Fallback Rendering */}
-              <section class="bg-white rounded-3xl shadow-xl p-8"><h2 class="text-3xl font-bold text-gray-900 mb-8">费用详情</h2><div class="space-y-6"><div class="grid md:grid-cols-2 gap-4">{isVirtual && <div class="bg-blue-50 rounded-xl p-4 border border-blue-100"><p class="text-sm text-gray-600">虚拟卡费用</p><p class="text-xl font-bold text-gray-900">{virtualCardPrice === 0 ? '免费' : `${virtualCardPrice}`}</p></div>}<div class="bg-purple-50 rounded-xl p-4 border border-purple-100"><p class="text-sm text-gray-600">实体卡费用</p><p class="text-xl font-bold text-gray-900">{!isPhysical ? 'N/A' : physicalCardPrice === 0 ? '免费' : `${physicalCardPrice}`}</p></div></div><div class="space-y-3"><div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">充值费用</span><span class="font-medium">{depositFee || 'N/A'}</span></div><div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">交易手续费</span><span class="font-medium">{transactionFee || 'N/A'}</span></div><div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">ATM取现费</span><span class="font-medium">{atmFee || 'N/A'}</span></div></div>{annualFee !== undefined && <div class="p-3 bg-yellow-50 border border-yellow-100 rounded-lg flex justify-between items-center"><span class="text-gray-700">年费</span><span class={`font-bold ${annualFee ? 'text-orange-600' : 'text-green-600'}`}>{annualFee ? '收费' : '免费'}</span></div>}</div></section>
+              <section class="bg-white rounded-3xl shadow-xl p-8">
+                <h2 class="text-3xl font-bold text-gray-900 mb-8">费用详情</h2>
+                <div class="space-y-6">
+                    <div class="grid md:grid-cols-2 gap-4">
+                      {isVirtual && <div class="bg-blue-50 rounded-xl p-4 border border-blue-100"><p class="text-sm text-gray-600">虚拟卡费用</p><p class="text-xl font-bold text-gray-900">{virtualCardPrice === 0 ? '免费' : `${virtualCardPrice}`}</p></div>}
+                      <div class="bg-purple-50 rounded-xl p-4 border border-purple-100"><p class="text-sm text-gray-600">实体卡费用</p><p class="text-xl font-bold text-gray-900">{!isPhysical ? 'N/A' : physicalCardPrice === 0 ? '免费' : `${physicalCardPrice}`}</p></div>
+                    </div>
+                    <div class="space-y-3">
+                      <div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">充值费用</span><span class="font-medium">{depositFee || 'N/A'}</span></div>
+                      <div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">交易手续费</span><span class="font-medium">{transactionFee || 'N/A'}</span></div>
+                      <div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">提现手续费</span><span class="font-medium">{isVirtual && !isPhysical ? '暂不支持' : (withdrawalFee || 'N/A')}</span></div>
+                      <div class="flex justify-between p-3 bg-gray-50 rounded-lg"><span class="text-gray-700">ATM取现费</span><span class="font-medium">{atmFee || 'N/A'}</span></div>
+                    </div>
+                    {annualFee !== undefined && <div class="p-3 bg-yellow-50 border border-yellow-100 rounded-lg flex justify-between items-center"><span class="text-gray-700">年费</span><span class={`font-bold ${annualFee ? 'text-orange-600' : 'text-green-600'}`}>{annualFee ? '收费' : '免费'}</span></div>}
+                </div>
+              </section>
               {limits && <section class="bg-white rounded-3xl shadow-xl p-8"><h2 class="text-3xl font-bold text-gray-900 mb-8">消费限额</h2><div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">{Object.entries(limits).map(([key, value]) => { const limitLabels = { dailySpending: '每日消费', monthlySpending: '每月消费', singleTransaction: '单笔交易', dailyAtmWithdrawal: '每日ATM取款', monthlyAtmWithdrawal: '每月ATM取款', lifetimeLimit: '终身限额' }; return value ? <div class="p-4 bg-indigo-50 rounded-xl border border-indigo-100"><p class="text-sm text-gray-600">{limitLabels[key] || key}</p><p class="text-lg font-bold text-indigo-600">{value}</p></div> : null; })}</div></section>}
               <section class="bg-white rounded-3xl shadow-xl p-8"><h2 class="text-3xl font-bold text-gray-900 mb-8">支持的加密货币</h2>{supportedCurrencies && supportedCurrencies.length > 0 ? <div class="flex flex-wrap items-center gap-3">{supportedCurrencies.map(currency => { const currencyInfo = getCurrencyInfo(currency); return <div class="flex flex-col items-center p-2 group cursor-pointer"><div class={`w-14 h-14 bg-gradient-to-br ${currencyInfo.bgGradient} rounded-full flex items-center justify-center text-white shadow-lg group-hover:scale-110 transition-transform duration-300 text-xl font-bold mb-2`}><img src={currencyInfo.icon} alt={`${currencyInfo.name} icon`} class="w-8 h-8" /></div><span class={`text-xs font-medium ${currencyInfo.textColor} opacity-80 group-hover:opacity-100`}>{currencyInfo.symbol}</span></div>; })}</div> : <p>暂无数据</p>}</section>
               <section class="bg-white rounded-3xl shadow-xl p-8"><h2 class="text-3xl font-bold text-gray-900 mb-8">支持的支付方式</h2>{supportedPaymentMethods && supportedPaymentMethods.length > 0 ? <div class="grid grid-cols-2 md:grid-cols-4 gap-6">{supportedPaymentMethods.map(method => { const info = getPaymentMethodInfo(method); return <div class={`group flex flex-col items-center p-6 ${info.bgLight} rounded-2xl border-2 ${info.borderColor} hover:scale-105 hover:shadow-lg transition-all`}><div class={`relative w-16 h-16 bg-gradient-to-br ${info.bgGradient} rounded-2xl flex items-center justify-center mb-4 shadow-md group-hover:scale-110`}><img src={info.icon} alt={`${info.name} icon`} class="w-8 h-8" /></div><span class={`font-bold ${info.textColor} text-center`}>{info.name}</span></div>; })}</div> : <p>暂无数据</p>}</section>
@@ -352,7 +367,6 @@ const structuredData = {
               {features && features.length > 0 && <section class="bg-white rounded-3xl shadow-xl p-8"><h2 class="text-3xl font-bold text-gray-900 mb-8">特色功能</h2><div class="grid md:grid-cols-2 gap-4">{features.map(feature => <div class="flex items-center p-4 bg-indigo-50 rounded-xl"><svg class="w-6 h-6 text-indigo-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg><span class="text-gray-800 font-medium">{feature}</span></div>)}</div></section>}
             </div>
           )}
-           
           <GiscusComments title={`${name} 用户评论`} />
         </div>
 


### PR DESCRIPTION
…cture and includes a minor fix for the legacy layout.

Key changes:

1.  **Layout Fix (`[slug].astro`):**
    *   Added logic to the legacy (single-tier) layout to correctly display "暂不支持" (Not Supported) for the withdrawal fee on virtual-only cards, improving data accuracy.

2.  **`crypto-com-card.md` Migration:**
    *   The frontmatter has been completely refactored to use the `tiers` array.
    *   Created three distinct tiers (Midnight Blue, Ruby Steel, Jade Green/Royal Indigo) to showcase the card's different levels in the new side-by-side comparison view.

3.  **`onekey-card.md` Migration:**
    *   Refactored the frontmatter to use the `tiers` array with a single tier. This moves the card to the new component, ensuring a consistent, modern UI across all card pages.