### PR TITLE
Fix: Remove extra margin on card detail page

### DIFF
--- a/src/pages/cards/[slug].astro
+++ b/src/pages/cards/[slug].astro
@@ -237,9 +237,9 @@ const structuredData = {
       <>
         <script slot="head" type="application/ld+json" set:html={JSON.stringify(structuredData)} />
 
-        <div class="min-h-screen bg-gradient-to-br from-gray-50 to-indigo-50 py-16">
+        <div class="min-h-screen bg-gradient-to-br from-gray-50 to-indigo-50 pb-16">
           <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div class="mb-12 overflow-hidden rounded-3xl bg-white shadow-2xl">
+            <div class="overflow-hidden rounded-3xl bg-white shadow-2xl">
               <div class="relative">
                 <div class="absolute inset-0 bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500" />
                 <div class="relative p-8 lg:p-12">


### PR DESCRIPTION
Removes the `mb-12` class from the main content container in `src/pages/cards/[slug].astro`. This class was adding unnecessary margin and creating a visual gap between the header and the content.